### PR TITLE
Add support for topic renames

### DIFF
--- a/src/@types/dom.d.ts
+++ b/src/@types/dom.d.ts
@@ -1,4 +1,5 @@
 import {Chapter, Topic} from '../model/model';
+import {ChapterRenameArgs} from '../view/ChapterElement';
 import {ChapterCreationArgs} from '../view/ContentExplorer';
 import {ChapterChangeArgs} from '../view/ContentViewer';
 
@@ -10,6 +11,7 @@ declare global {
     inputProvided: CustomEvent<string>;
     inputCancelled: Event;
     topicSelected: CustomEvent<Topic>;
+    renameChapterRequseted: CustomEvent<ChapterRenameArgs>;
     chapterContentChanged: CustomEvent<ChapterChangeArgs>;
     showChapterRequestedForm: CustomEvent<Topic>;
   }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,8 +1,10 @@
-export function del<T>(arr: T[], elem: T): void {
+export function del<T>(arr: T[], elem: T): boolean {
   const index = arr.indexOf(elem);
   if (index >= 0) {
     arr.splice(index, 1);
+    return true;
   }
+  return false;
 }
 
 export function computeIfAbsent<K, V>(

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -35,23 +35,13 @@ export class Topic {
   }
 
   public removeChapter(chapter: Chapter): void {
-    del<Chapter>(this.chapters, chapter);
-    chapter.__dangerouslySetBacklink(null);
+    if (del<Chapter>(this.chapters, chapter)) {
+      chapter.__dangerouslySetBacklink(null);
+    }
   }
 
   public getChapters(): Array<Chapter> {
     return this.chapters;
-  }
-
-  public checksum(): string {
-    return (
-      this.getId() +
-      '-' +
-      this.chapters
-        .map(c => c.getId())
-        .toSorted()
-        .reduce((id1, id2) => id1 + '-' + id2, '')
-    );
   }
 }
 

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -39,3 +39,8 @@
   grid-column: 1/4;
   grid-row: 3;
 }
+
+.ide-styled-grid > .init-message-screen {
+  grid-column: 1/4;
+  grid-row: 2/3;
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -165,6 +165,19 @@ samp {
   outline: none;
 }
 
+.init-message-screen {
+  background-color: #302f2f;
+  color: #ddd;
+}
+
+.init-message {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  -webkit-transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%);
+}
+
 .footer {
   font-size: 0.8em;
   background: #302f2f;

--- a/src/view/ButtonlessForm.tsx
+++ b/src/view/ButtonlessForm.tsx
@@ -18,7 +18,7 @@ export class ButtonlessForm extends React.Component<ButtonlessFormProps, {}> {
         onSubmit={e => {
           e.preventDefault(); //To prevent reload
           const name = this.inputRef.current?.value;
-          if (name) {
+          if (name && name.trim().length > 0) {
             e.currentTarget.dispatchEvent(
               new CustomEvent<string>('inputProvided', {
                 detail: name,

--- a/src/view/ChapterElement.tsx
+++ b/src/view/ChapterElement.tsx
@@ -11,6 +11,11 @@ export interface ChapterState {
   chapter: Chapter;
 }
 
+export type ChapterRenameArgs = {
+  chapter: Chapter;
+  newName: string;
+};
+
 export class ChapterElement extends React.Component<
   ChapterProps,
   ChapterState
@@ -44,7 +49,7 @@ export class ChapterElement extends React.Component<
         <form
           onSubmit={e => {
             e.preventDefault();
-            this.state.chapter.setDisplayName(this.state.newChapterName);
+            this.renameChapter(this.state.newChapterName);
             this.hideEditor();
           }}
           onAbort={e => {
@@ -100,6 +105,20 @@ export class ChapterElement extends React.Component<
       liElem.dispatchEvent(
         new CustomEvent<Chapter>('chapterSelected', {
           detail: this.props.chapter,
+          bubbles: true,
+          cancelable: false,
+          composed: false,
+        })
+      );
+    }
+  }
+
+  private renameChapter(newName: string): void {
+    const liElem = this.liRef.current as HTMLLIElement;
+    if (liElem) {
+      liElem.dispatchEvent(
+        new CustomEvent<ChapterRenameArgs>('renameChapterRequseted', {
+          detail: {chapter: this.props.chapter, newName: newName},
           bubbles: true,
           cancelable: false,
           composed: false,

--- a/src/view/ContentExplorer.tsx
+++ b/src/view/ContentExplorer.tsx
@@ -98,15 +98,10 @@ export class ContentExplorer extends React.Component<
     nextProps: Readonly<ExplorerProps>,
     nextState: Readonly<ExplorerState>
   ): boolean {
-    const currChecksum = this.props.topics
-      .map(t => t.checksum())
-      .reduce((s1, s2) => s1 + '-' + s2, '');
-    const nextChecksum = nextProps.topics
-      .map(t => t.checksum())
-      .reduce((s1, s2) => s1 + '-' + s2, '');
     return (
-      currChecksum !== nextChecksum ||
+      nextProps.topics !== this.props.topics ||
       nextState.isAddingTopic !== this.state.isAddingTopic ||
+      nextState.selectedTopicElement !== this.state.selectedTopicElement ||
       nextState.selectedChapterElement !== this.state.selectedChapterElement
     );
   }
@@ -145,14 +140,16 @@ export class ContentExplorer extends React.Component<
         </nav>
         <ul id="explorer-items" className="tree">
           {topicLiElems}
-          {this.state.isAddingTopic && (
-            <li>
-              <ButtonlessForm
-                promptText="Enter topic name"
-                ref={this.createTopicElemRef}
-              />
-            </li>
-          )}
+          <li
+            style={{
+              display: this.state.isAddingTopic ? 'inline-block' : 'none',
+            }}
+          >
+            <ButtonlessForm
+              promptText="Enter topic name"
+              ref={this.createTopicElemRef}
+            />
+          </li>
         </ul>
       </div>
     );


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #10

Summary
1. Add support for chapter name.
2. Optimise tree refresh logic.
3. Use buttonless form for new store creation.
4. Start the app with a nice banner message.