### PR TITLE
Support for topic delete [2/n]

### DIFF
--- a/src/@types/dom.d.ts
+++ b/src/@types/dom.d.ts
@@ -7,7 +7,7 @@ declare global {
   interface GlobalEventHandlersEventMap {
     chapterSelected: CustomEvent<Chapter>;
     newTopicRequested: CustomEvent<string>;
-    deleteTopicRequested: CustomEvent<string>;
+    deleteTopicRequested: CustomEvent<Topic>;
     newChapterRequested: CustomEvent<ChapterCreationArgs>;
     inputProvided: CustomEvent<string>;
     inputCancelled: Event;

--- a/src/view/App.tsx
+++ b/src/view/App.tsx
@@ -68,6 +68,10 @@ export class App
       'renameChapterRequseted',
       this.renameChapterRequseted.bind(this)
     );
+    document.addEventListener(
+      'deleteTopicRequested',
+      this.deleteTopicRequested.bind(this)
+    );
     const topicInputElem = ReactDOM.findDOMNode(
       this.storeNameInput.current
     ) as HTMLElement;
@@ -311,6 +315,13 @@ export class App
     }
   }
 
+  private async deleteTopicRequested(e: CustomEvent<Topic>): Promise<void> {
+    const controller = this.state.contentController;
+    if (controller) {
+      await controller.deleteTopic(e.detail);
+    }
+  }
+
   private async createNewChapter(
     e: CustomEvent<ChapterCreationArgs>
   ): Promise<void> {
@@ -334,7 +345,11 @@ export class App
   }
 
   onTopicCreated(topic: Topic): void {
-    this.setState({topics: this.state.topics.concat(topic)});
+    this.setState({
+      topics: this.state.topics.concat(topic),
+      selectedChapter: null,
+      selectedTopic: topic,
+    });
   }
 
   onTopicRenamed(_topic: Topic, _newName: string): void {
@@ -344,11 +359,20 @@ export class App
   onTopicDeleted(topic: Topic): void {
     this.setState({
       topics: this.state.topics.filter(t => t.getId() !== topic.getId()),
+      selectedChapter:
+        this.state.selectedChapter?.getTopic() === topic
+          ? null
+          : this.state.selectedChapter,
+      selectedTopic:
+        this.state.selectedTopic === topic ? null : this.state.selectedTopic,
     });
   }
 
-  onChapterCreated(_chapter: Chapter): void {
-    this.setState({topics: this.state.topics.map(x => x)});
+  onChapterCreated(chapter: Chapter): void {
+    this.setState({
+      topics: this.state.topics.map(x => x),
+      selectedChapter: chapter,
+    });
   }
 
   onChapterMoved(_chapter: Chapter, _newTopic: Topic): void {
@@ -360,7 +384,13 @@ export class App
     this.setState({topics: this.state.topics.map(x => x)});
   }
 
-  onChapterDeleted(_chapter: Chapter): void {
-    this.setState({topics: this.state.topics.map(x => x)});
+  onChapterDeleted(chapter: Chapter): void {
+    this.setState({
+      topics: this.state.topics.map(x => x),
+      selectedChapter:
+        this.state.selectedChapter === chapter
+          ? null
+          : this.state.selectedChapter,
+    });
   }
 }

--- a/src/view/ContentExplorer.tsx
+++ b/src/view/ContentExplorer.tsx
@@ -127,15 +127,17 @@ export class ContentExplorer extends React.Component<
                 create_new_folder
               </button>
             </li>
-            <li>
-              <button
-                className={'navBtn material-symbols-outlined'}
-                onClick={this.createNewChapter.bind(this)}
-                title="Add a new chapter under the current topic"
-              >
-                new_window
-              </button>
-            </li>
+            {this.state.selectedTopic !== null && (
+              <li>
+                <button
+                  className={'navBtn material-symbols-outlined'}
+                  onClick={this.createNewChapter.bind(this)}
+                  title="Add a new chapter under the current topic"
+                >
+                  new_window
+                </button>
+              </li>
+            )}
           </ul>
         </nav>
         <ul id="explorer-items" className="tree">

--- a/src/view/TopicElement.tsx
+++ b/src/view/TopicElement.tsx
@@ -122,16 +122,26 @@ export class TopicElement extends React.Component<
     );
   }
 
-  private deleteTopicRequested(): void {
-    const myDOM = ReactDOM.findDOMNode(this);
-    myDOM?.dispatchEvent(
-      new CustomEvent<Topic>('deleteTopicRequested', {
-        detail: this.props.topic,
-        bubbles: true,
-        cancelable: true,
-        composed: false,
-      })
-    );
+  private deleteTopicRequested(e: React.MouseEvent): void {
+    if (
+      !confirm(
+        'Are you sure you want to delete topic: ' +
+          this.props.topic.getDisplayName() +
+          '?'
+      )
+    ) {
+      e.preventDefault();
+    } else {
+      const myDOM = ReactDOM.findDOMNode(this);
+      myDOM?.dispatchEvent(
+        new CustomEvent<Topic>('deleteTopicRequested', {
+          detail: this.props.topic,
+          bubbles: true,
+          cancelable: true,
+          composed: false,
+        })
+      );
+    }
   }
 
   private chapterCreationCancelled(): void {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #19
* __->__ #18
* #17

Summary:
1. Wired events to delete topic.
2. Fixed a bug in chapter delete.
3. Fixed logic to update state after topic/chapte delete/create.

Test Plan:
1. Manually.