### PR TITLE
Cleaner event hiearchy

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+.sl
+dist
+.vscode
+node_modules
+.git
+.hg

--- a/src/@types/dom.d.ts
+++ b/src/@types/dom.d.ts
@@ -5,16 +5,16 @@ import {ChapterChangeArgs} from '../view/ContentViewer';
 
 declare global {
   interface GlobalEventHandlersEventMap {
-    chapterSelected: CustomEvent<Chapter>;
+    selectChapterRequested: CustomEvent<Chapter>;
+    selectTopicRequested: CustomEvent<Topic>;
     newTopicRequested: CustomEvent<string>;
-    deleteTopicRequested: CustomEvent<Topic>;
     newChapterRequested: CustomEvent<ChapterCreationArgs>;
+    deleteTopicRequested: CustomEvent<Topic>;
+    deleteChapterRequested: CustomEvent<Chapter>;
     inputProvided: CustomEvent<string>;
     inputCancelled: Event;
-    topicSelected: CustomEvent<Topic>;
     renameChapterRequseted: CustomEvent<ChapterRenameArgs>;
     chapterContentChanged: CustomEvent<ChapterChangeArgs>;
-    showChapterRequestedForm: CustomEvent<Topic>;
   }
 }
 export {}; //keep that for TS compiler.

--- a/src/controller/contentcontroller.ts
+++ b/src/controller/contentcontroller.ts
@@ -12,6 +12,7 @@ export interface ContentObserver {
   onChapterMoved(chapter: Chapter, newTopic: Topic): void;
   onChapterRenamed(chapter: Chapter, newName: string): void;
   onChapterDeleted(chapter: Chapter): void;
+  onChapterSaved(chapter: Chapter, saveTs: Date): void;
 }
 
 export interface ContentController {

--- a/src/controller/fs.ts
+++ b/src/controller/fs.ts
@@ -224,7 +224,9 @@ export class FileSystemController implements ContentController {
   }
 
   public async saveChapter(chapter: Chapter, text: string): Promise<void> {
+    const saveTs = new Date();
     this.createOrUpdateChapter(chapter, text, false);
+    this.observers.forEach(obs => obs.onChapterSaved(chapter, saveTs));
   }
 
   private async createOrUpdateChapter(

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -19,3 +19,12 @@ export function computeIfAbsent<K, V>(
   map.set(key, val);
   return val;
 }
+
+export function pop<K, V>(map: Map<K, V>): V | null {
+  if (map.size > 0) {
+    const [key, val] = map.entries().next().value;
+    map.delete(key);
+    return val;
+  }
+  return null;
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -156,7 +156,6 @@ button.explorer-mini-btn:hover {
     outline: none;
     background-color: rgb(250, 250, 255);
   }
-  li.chapter:hover,
   li.chapter:active,
   li.chapter:focus,
   li.chapter.selected,
@@ -166,6 +165,9 @@ button.explorer-mini-btn:hover {
     border-color: green;
     font-weight: normal;
     text-decoration: none;
+  }
+  li.chapter:hover {
+    border-color: rgb(203, 203, 0);
   }
   a:hover {
     font-weight: normal;

--- a/src/view/ButtonlessForm.tsx
+++ b/src/view/ButtonlessForm.tsx
@@ -32,16 +32,20 @@ export class ButtonlessForm extends React.Component<ButtonlessFormProps, {}> {
       <form
         onSubmit={e => {
           e.preventDefault(); //To prevent reload
-          const name = this.inputRef.current?.value;
-          if (name && name.trim().length > 0) {
-            e.currentTarget.dispatchEvent(
-              new CustomEvent<string>('inputProvided', {
-                detail: name,
-                bubbles: true,
-                cancelable: true,
-                composed: false,
-              })
-            );
+          const inputElem = this.inputRef.current;
+          if (inputElem) {
+            const name = inputElem.value;
+            if (name && name.trim().length > 0) {
+              e.currentTarget.dispatchEvent(
+                new CustomEvent<string>('inputProvided', {
+                  detail: name,
+                  bubbles: true,
+                  cancelable: true,
+                  composed: false,
+                })
+              );
+            }
+            inputElem.value = '';
           }
         }}
         onAbort={e => {

--- a/src/view/ChapterElement.tsx
+++ b/src/view/ChapterElement.tsx
@@ -8,7 +8,7 @@ export interface ChapterProps {
 export interface ChapterState {
   editingName: boolean;
   newChapterName: string;
-  chapter: Chapter;
+  isSelected: boolean;
 }
 
 export type ChapterRenameArgs = {
@@ -28,7 +28,7 @@ export class ChapterElement extends React.Component<
     this.liRef = createRef();
     this.editorRef = createRef();
     this.state = {
-      chapter: chapterProps.chapter,
+      isSelected: false,
       editingName: false,
       newChapterName: chapterProps.chapter.getDisplayName(),
     };
@@ -36,7 +36,10 @@ export class ChapterElement extends React.Component<
 
   public render() {
     return (
-      <li ref={this.liRef} className="chapter">
+      <li
+        ref={this.liRef}
+        className={'chapter' + (this.state.isSelected ? ' selected' : '')}
+      >
         <a
           onClick={this.loadChapter.bind(this)}
           onDoubleClick={this.showEditor.bind(this)}
@@ -44,7 +47,7 @@ export class ChapterElement extends React.Component<
             this.state.editingName ? {display: 'none'} : {display: 'block'}
           }
         >
-          {this.state.chapter.getDisplayName()}
+          {this.props.chapter.getDisplayName()}
         </a>
         <form
           onSubmit={e => {
@@ -77,6 +80,13 @@ export class ChapterElement extends React.Component<
     );
   }
 
+  public markSelected(isSelected: boolean) {
+    this.setState({isSelected: isSelected});
+    if (!isSelected) {
+      this.setState({editingName: false});
+    }
+  }
+
   private showEditor(e: React.MouseEvent) {
     this.loadChapter();
     this.setState({editingName: true});
@@ -89,7 +99,7 @@ export class ChapterElement extends React.Component<
   }
 
   private hideEditor() {
-    this.setState({editingName: false});
+    this.setState({editingName: false, newChapterName: ''});
   }
 
   private processKeyboardInput(e: React.KeyboardEvent): void {
@@ -102,7 +112,7 @@ export class ChapterElement extends React.Component<
     const liElem = this.liRef.current as HTMLLIElement;
     if (liElem) {
       liElem.dispatchEvent(
-        new CustomEvent<Chapter>('chapterSelected', {
+        new CustomEvent<Chapter>('selectChapterRequested', {
           detail: this.props.chapter,
           bubbles: true,
           cancelable: false,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #19
* #18
* #17

Summary:
1. Handle all event business logic at App level.
2. Only transform and bubble up events from children.
3. Fix filesystem async event ordering.
4. Change style to distinguish between chapter
hover and selection.
5. Fix timer scheduling and unscheduling.


Test Plan:
Manually.