### PR TITLE
Fix chapter load/save overlap issues

### DIFF
--- a/src/view/ChapterElement.tsx
+++ b/src/view/ChapterElement.tsx
@@ -37,7 +37,7 @@ export class ChapterElement extends React.Component<
     return (
       <li
         className={'chapter' + (this.state.isSelected ? ' selected' : '')}
-        onClick={this.loadChapter.bind(this)}
+        onClick={this.selectChapterRequested.bind(this)}
         onDoubleClick={this.showEditor.bind(this)}
       >
         {this.state.editingName ? (
@@ -118,7 +118,10 @@ export class ChapterElement extends React.Component<
     }
   }
 
-  private loadChapter(): void {
+  private selectChapterRequested(): void {
+    if (this.state.isSelected) {
+      return; //No need to fire the event if we are already selected
+    }
     const me = ReactDOM.findDOMNode(this);
     me?.dispatchEvent(
       new CustomEvent<Chapter>('selectChapterRequested', {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #33
* #32
* __->__ #31
* #29

Summary:

1. Do not load a chapter if it is already loaded. This can cause unsaved changes to be lost.
2. Do not load chapters before the save queue is clear.
3. To implement #2, use intervals instead of timers and `await` on the save chapters method to ensure the queue is clear before a read operation is made.
4. This also fixes an issue where read/write operations clash causing bad file state.